### PR TITLE
fix: emoji annoys string.count

### DIFF
--- a/RegeributedTextView/Classes/RegeributedTextView.swift
+++ b/RegeributedTextView/Classes/RegeributedTextView.swift
@@ -150,7 +150,7 @@ open class RegeributedTextView: UITextView {
     
     fileprivate var tapAttributedTextGesture: UITapGestureRecognizer?
     
-    private var _delegate: RegeributedTextViewDelegate?
+    private weak var _delegate: RegeributedTextViewDelegate?
     
     private var attributedRanges: [AttributedRange] = [] {
         didSet {

--- a/RegeributedTextView/Classes/StringExt.swift
+++ b/RegeributedTextView/Classes/StringExt.swift
@@ -23,7 +23,7 @@ extension String {
     // Returns matched range list by regular expression.
     func matched(by regex: String) -> [Range<String.Index>] {
         let result = try? NSRegularExpression(pattern: regex, options: [])
-            .matches(in: self, options: [], range: NSRange(location: 0, length: self.count))
+            .matches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count))
             .flatMap{ $0.range(at: 0).range(for: self) }
         return result ?? []
     }


### PR DESCRIPTION
Sorry, this pull request is Japanese only!!

## 問題

文字列に絵文字が含まれていた場合、絵文字の数だけNSRangeの末尾がカットされているようです。
```swift
// addAttribute(.hashTag, attribute: .textColor(.red)) で赤くなる文字
"hoge #fuga" // => #fuga
"hoge🍣 #fuga" // => #fug
"hoge🍣🍶 #fuga" // => #fu
```

## 解決策

UTF16に変換してcountすることで解決すると思われます。